### PR TITLE
feat: Add DMCA protection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -439,7 +439,9 @@
                     <a href="#faq" data-umami-event="Footer FAQ Click">FAQ</a>
                     <a href="#how-it-works" data-umami-event="Footer How Morphe Works Click">How Morphe Works</a>
                     <a href="/donate" data-umami-event="Footer Donate Click">Donate</a>
-                    <a href="https://www.dmca.com/Protection/Status.aspx?ID=58df7b1f-ce9f-4a91-9b07-c79cf576230b" title="DMCA.com Protection Status" class="dmca-badge"> <img src ="https://images.dmca.com/Badges/dmca_protected_sml_120n.png?ID=58df7b1f-ce9f-4a91-9b07-c79cf576230b"  alt="DMCA.com Protection Status" /></a>  <script src="https://images.dmca.com/Badges/DMCABadgeHelper.min.js"> </script>
+                    <a href="https://www.dmca.com/Protection/Status.aspx?ID=58df7b1f-ce9f-4a91-9b07-c79cf576230b" title="DMCA.com Protection Status" class="dmca-badge">
+                        <img src ="https://images.dmca.com/Badges/dmca_protected_sml_120n.png?ID=58df7b1f-ce9f-4a91-9b07-c79cf576230b" alt="DMCA.com Protection Status" />
+                    </a><script src="https://images.dmca.com/Badges/DMCABadgeHelper.min.js"></script>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adds DMCA badge, which gives us free DMCA takedowns for scam sites.

Clicking the badge shows "unverified" right now because it's on a dev deploy so the referring url isn't right. But it should "just work" after merged to main.

https://31-merge.morphe-website.pages.dev/