### PR TITLE
feat: Show supported apps before how-to section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -146,6 +146,30 @@
         </div>
     </div>
 
+    <div class="supported-apps">
+        <h3 class="supported-title" data-i18n="how-it-works.supported-title">Supported Apps</h3>
+        <div class="app-badges">
+            <div class="app-badge">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 5v14l11-7z"/>
+                </svg>
+                <span>YouTube</span>
+            </div>
+            <div class="app-badge">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+                </svg>
+                <span>YouTube Music</span>
+            </div>
+            <div class="app-badge">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>
+                </svg>
+                <span>Reddit</span>
+            </div>
+        </div>
+    </div>
+
     <!-- Social Links -->
     <div class="social-section">
         <p class="social-label" data-i18n="hero.social-label">Join the Community</p>
@@ -230,30 +254,6 @@
                 <p class="feature-description" data-i18n="how-it-works.step4-desc">
                     Install the patched app and enjoy your customized experience.
                 </p>
-            </div>
-        </div>
-
-        <div class="supported-apps">
-            <h3 class="supported-title" data-i18n="how-it-works.supported-title">Supported Apps</h3>
-            <div class="app-badges">
-                <div class="app-badge">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M8 5v14l11-7z"/>
-                    </svg>
-                    <span>YouTube</span>
-                </div>
-                <div class="app-badge">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
-                    </svg>
-                    <span>YouTube Music</span>
-                </div>
-                <div class="app-badge">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>
-                    </svg>
-                    <span>Reddit</span>
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Moves the supported apps section before the social links and 'how-to' section

Can later revert if the analytics suggest it was better before.

https://82-merge.morphe-website.pages.dev/
