### PR TITLE
fix: add rel attributes to external links

### DIFF
--- a/public/changelog.html
+++ b/public/changelog.html
@@ -118,6 +118,7 @@
             <div class="show-more-buttons">
                 <a href="https://github.com/MorpheApp/morphe-manager/releases"
                    target="_blank"
+                   rel="noopener noreferrer"
                    class="btn btn-secondary"
                    data-umami-event="Changelog Show More Manager">
                     <span data-i18n="changelog.view-manager">View Manager Releases</span>
@@ -125,6 +126,7 @@
                 </a>
                 <a href="https://github.com/MorpheApp/morphe-patches/releases"
                    target="_blank"
+                   rel="noopener noreferrer"
                    class="btn btn-secondary"
                    data-umami-event="Changelog Show More Patches">
                     <span data-i18n="changelog.view-patches">View Patches Releases</span>
@@ -177,10 +179,10 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" data-umami-event="Footer Reddit Click">Reddit</a>
-                    <a href="https://crowdin.com/project/morphe" target="_blank" data-umami-event="Footer Crowdin Click">Crowdin</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">
                     <h4 data-i18n="footer.language">Language</h4>

--- a/public/changelog.html
+++ b/public/changelog.html
@@ -118,7 +118,7 @@
             <div class="show-more-buttons">
                 <a href="https://github.com/MorpheApp/morphe-manager/releases"
                    target="_blank"
-                   rel="noopener noreferrer"
+                   rel="noopener"
                    class="btn btn-secondary"
                    data-umami-event="Changelog Show More Manager">
                     <span data-i18n="changelog.view-manager">View Manager Releases</span>
@@ -126,7 +126,7 @@
                 </a>
                 <a href="https://github.com/MorpheApp/morphe-patches/releases"
                    target="_blank"
-                   rel="noopener noreferrer"
+                   rel="noopener"
                    class="btn btn-secondary"
                    data-umami-event="Changelog Show More Patches">
                     <span data-i18n="changelog.view-patches">View Patches Releases</span>
@@ -179,9 +179,9 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer Reddit Click">Reddit</a>
                     <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">

--- a/public/donate.html
+++ b/public/donate.html
@@ -294,10 +294,10 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" data-umami-event="Footer Reddit Click">Reddit</a>
-                    <a href="https://crowdin.com/project/morphe" target="_blank" data-umami-event="Footer Crowdin Click">Crowdin</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">
                     <h4 data-i18n="footer.language">Language</h4>

--- a/public/donate.html
+++ b/public/donate.html
@@ -294,9 +294,9 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer Reddit Click">Reddit</a>
                     <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">

--- a/public/index.html
+++ b/public/index.html
@@ -481,28 +481,28 @@
             <p class="section-subtitle" data-i18n="community.subtitle">Follow us, report issues, and help make Morphe better</p>
         </div>
         <div class="community-grid">
-            <a href="https://github.com/MorpheApp" target="_blank" class="community-card" data-umami-event="GitHub Link Click">
+            <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="GitHub Link Click">
                 <div class="feature-icon">
                     <img src="images/github.svg" alt="GitHub" class="community-icon-img">
                 </div>
                 <h3 class="feature-title">GitHub</h3>
                 <p class="feature-description" data-i18n="community.github-desc">Browse the source code, report bugs, and contribute to Morphe development.</p>
             </a>
-            <a href="https://x.com/MorpheApp" target="_blank" class="community-card" data-umami-event="X Link Click">
+            <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="X Link Click">
                 <div class="feature-icon">
                     <img src="images/X.svg" alt="X" class="community-icon-img">
                 </div>
                 <h3 class="feature-title">X (Twitter)</h3>
                 <p class="feature-description" data-i18n="community.x-desc">Stay up to date with the latest news, releases, and announcements.</p>
             </a>
-            <a href="https://reddit.com/r/MorpheApp" target="_blank" class="community-card" data-umami-event="Reddit Link Click">
+            <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="Reddit Link Click">
                 <div class="feature-icon">
                     <img src="images/reddit.svg" alt="Reddit" class="community-icon-img">
                 </div>
                 <h3 class="feature-title">Reddit</h3>
                 <p class="feature-description" data-i18n="community.reddit-desc">Join discussions, share tips, and connect with other Morphe users.</p>
             </a>
-            <a href="https://crowdin.com/project/morphe" target="_blank" class="community-card" data-umami-event="Crowdin Link Click">
+            <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="Crowdin Link Click">
                 <div class="feature-icon">
                     <img src="images/crowdin-small.svg" alt="Crowdin" class="community-icon-img">
                 </div>
@@ -555,10 +555,10 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" data-umami-event="Footer Reddit Click">Reddit</a>
-                    <a href="https://crowdin.com/project/morphe" target="_blank" data-umami-event="Footer Crowdin Click">Crowdin</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">
                     <h4 data-i18n="footer.language">Language</h4>

--- a/public/index.html
+++ b/public/index.html
@@ -481,21 +481,21 @@
             <p class="section-subtitle" data-i18n="community.subtitle">Follow us, report issues, and help make Morphe better</p>
         </div>
         <div class="community-grid">
-            <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="GitHub Link Click">
+            <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" class="community-card" data-umami-event="GitHub Link Click">
                 <div class="feature-icon">
                     <img src="images/github.svg" alt="GitHub" class="community-icon-img">
                 </div>
                 <h3 class="feature-title">GitHub</h3>
                 <p class="feature-description" data-i18n="community.github-desc">Browse the source code, report bugs, and contribute to Morphe development.</p>
             </a>
-            <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="X Link Click">
+            <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" class="community-card" data-umami-event="X Link Click">
                 <div class="feature-icon">
                     <img src="images/X.svg" alt="X" class="community-icon-img">
                 </div>
                 <h3 class="feature-title">X (Twitter)</h3>
                 <p class="feature-description" data-i18n="community.x-desc">Stay up to date with the latest news, releases, and announcements.</p>
             </a>
-            <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" class="community-card" data-umami-event="Reddit Link Click">
+            <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" class="community-card" data-umami-event="Reddit Link Click">
                 <div class="feature-icon">
                     <img src="images/reddit.svg" alt="Reddit" class="community-icon-img">
                 </div>
@@ -555,9 +555,9 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer Reddit Click">Reddit</a>
                     <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">

--- a/public/microg.html
+++ b/public/microg.html
@@ -177,10 +177,10 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" data-umami-event="Footer Reddit Click">Reddit</a>
-                    <a href="https://crowdin.com/project/morphe" target="_blank" data-umami-event="Footer Crowdin Click">Crowdin</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">
                     <h4 data-i18n="footer.language">Language</h4>

--- a/public/microg.html
+++ b/public/microg.html
@@ -177,9 +177,9 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer Reddit Click">Reddit</a>
                     <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">

--- a/public/translate.html
+++ b/public/translate.html
@@ -227,10 +227,10 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" data-umami-event="Footer Reddit Click">Reddit</a>
-                    <a href="https://crowdin.com/project/morphe" target="_blank" data-umami-event="Footer Crowdin Click">Crowdin</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">
                     <h4 data-i18n="footer.language">Language</h4>

--- a/public/translate.html
+++ b/public/translate.html
@@ -227,9 +227,9 @@
                 </div>
                 <div class="footer-column">
                     <h4 data-i18n="footer.community">Community</h4>
-                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer GitHub Click">GitHub</a>
-                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer X Click">X (Twitter)</a>
-                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Reddit Click">Reddit</a>
+                    <a href="https://github.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer GitHub Click">GitHub</a>
+                    <a href="https://x.com/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer X Click">X (Twitter)</a>
+                    <a href="https://reddit.com/r/MorpheApp" target="_blank" rel="noopener" data-umami-event="Footer Reddit Click">Reddit</a>
                     <a href="https://crowdin.com/project/morphe" target="_blank" rel="noopener noreferrer" data-umami-event="Footer Crowdin Click">Crowdin</a>
                 </div>
                 <div class="footer-column language-selector-container">


### PR DESCRIPTION
Summary: Add rel='noopener noreferrer' to external links that open in new tabs across the homepage, footers, and changelog release links. Validation: npm run i18n:check.