### PR TITLE
fix: count untranslated strings in i18n completeness

### DIFF
--- a/.github/workflows/i18n_check.yml
+++ b/.github/workflows/i18n_check.yml
@@ -57,15 +57,15 @@ jobs:
           
           # Check for specific issues
           MISSING=$(grep -E "^\s+\d+/\d+ translated, [1-9]\d* missing" translation-report.txt | wc -l || echo "0")
-          UNTRANSLATED=$(grep -E "^\s+\d+/\d+ translated, \d+ missing, [1-9]\d* untranslated" translation-report.txt | wc -l || echo "0")
+          UNTRANSLATED_LOCALES=$(grep -E "^\s+\d+/\d+ translated, \d+ missing, [1-9]\d* untranslated" translation-report.txt | wc -l || echo "0")
           ZOMBIES=$(grep -E "^[a-z-]+: \d+ zombie key" translation-report.txt | wc -l || echo "0")
           
           echo "missing_count=$MISSING" >> $GITHUB_OUTPUT
-          echo "untranslated_count=$UNTRANSLATED" >> $GITHUB_OUTPUT
+          echo "untranslated_count=$UNTRANSLATED_LOCALES" >> $GITHUB_OUTPUT
           echo "zombie_count=$ZOMBIES" >> $GITHUB_OUTPUT
           
           # Determine if there are issues
-          if [ "$AVG" -eq 100 ] && [ "$MISSING" -eq 0 ] && [ "$UNTRANSLATED" -eq 0 ] && [ "$ZOMBIES" -eq 0 ]; then
+          if [ "$AVG" -eq 100 ] && [ "$MISSING" -eq 0 ] && [ "$UNTRANSLATED_LOCALES" -eq 0 ] && [ "$ZOMBIES" -eq 0 ]; then
             echo "has_issues=false" >> $GITHUB_OUTPUT
           else
             echo "has_issues=true" >> $GITHUB_OUTPUT
@@ -79,7 +79,7 @@ jobs:
           HAS_ISSUES="${{ steps.check_status.outputs.has_issues }}"
           EN_CHANGES="${{ steps.check_changes.outputs.changes }}"
           MISSING="${{ steps.check_status.outputs.missing_count }}"
-          UNTRANSLATED="${{ steps.check_status.outputs.untranslated_count }}"
+          UNTRANSLATED_LOCALES="${{ steps.check_status.outputs.untranslated_count }}"
           ZOMBIES="${{ steps.check_status.outputs.zombie_count }}"
           
           # Start building comment
@@ -124,8 +124,8 @@ jobs:
             if [ "$MISSING" -gt 0 ]; then
               echo "- ⚠️ **$MISSING** missing translation(s)" >> comment.md
             fi
-            if [ "$UNTRANSLATED" -gt 0 ]; then
-              echo "- ⚠️ **$UNTRANSLATED** locale(s) contain untranslated string(s)" >> comment.md
+            if [ "$UNTRANSLATED_LOCALES" -gt 0 ]; then
+              echo "- ⚠️ **$UNTRANSLATED_LOCALES** locale(s) contain untranslated string(s)" >> comment.md
             fi
             if [ "$ZOMBIES" -gt 0 ]; then
               echo "- 🧟 **$ZOMBIES** zombie key(s) found" >> comment.md
@@ -146,8 +146,11 @@ jobs:
             # Action items
             echo "### 🔧 Action Items" >> comment.md
             echo "" >> comment.md
-            if [ "$AVG" -lt 100 ]; then
-              echo "- Complete missing or untranslated strings for all locales" >> comment.md
+            if [ "$MISSING" -gt 0 ]; then
+              echo "- Complete missing translations for all locales" >> comment.md
+            fi
+            if [ "$UNTRANSLATED_LOCALES" -gt 0 ]; then
+              echo "- Translate untranslated strings (currently same as English) in all locales" >> comment.md
             fi
             if [ "$ZOMBIES" -gt 0 ]; then
               echo "- Remove unused translation keys from locale files" >> comment.md

--- a/.github/workflows/i18n_check.yml
+++ b/.github/workflows/i18n_check.yml
@@ -65,7 +65,7 @@ jobs:
           echo "zombie_count=$ZOMBIES" >> $GITHUB_OUTPUT
           
           # Determine if there are issues
-          if [ "$AVG" -eq 100 ] && [ "$MISSING" -eq 0 ] && [ "$ZOMBIES" -eq 0 ]; then
+          if [ "$AVG" -eq 100 ] && [ "$MISSING" -eq 0 ] && [ "$UNTRANSLATED" -eq 0 ] && [ "$ZOMBIES" -eq 0 ]; then
             echo "has_issues=false" >> $GITHUB_OUTPUT
           else
             echo "has_issues=true" >> $GITHUB_OUTPUT
@@ -79,6 +79,7 @@ jobs:
           HAS_ISSUES="${{ steps.check_status.outputs.has_issues }}"
           EN_CHANGES="${{ steps.check_changes.outputs.changes }}"
           MISSING="${{ steps.check_status.outputs.missing_count }}"
+          UNTRANSLATED="${{ steps.check_status.outputs.untranslated_count }}"
           ZOMBIES="${{ steps.check_status.outputs.zombie_count }}"
           
           # Start building comment
@@ -123,6 +124,9 @@ jobs:
             if [ "$MISSING" -gt 0 ]; then
               echo "- ⚠️ **$MISSING** missing translation(s)" >> comment.md
             fi
+            if [ "$UNTRANSLATED" -gt 0 ]; then
+              echo "- ⚠️ **$UNTRANSLATED** locale(s) contain untranslated string(s)" >> comment.md
+            fi
             if [ "$ZOMBIES" -gt 0 ]; then
               echo "- 🧟 **$ZOMBIES** zombie key(s) found" >> comment.md
             fi
@@ -143,7 +147,7 @@ jobs:
             echo "### 🔧 Action Items" >> comment.md
             echo "" >> comment.md
             if [ "$AVG" -lt 100 ]; then
-              echo "- Complete missing translations for all locales" >> comment.md
+              echo "- Complete missing or untranslated strings for all locales" >> comment.md
             fi
             if [ "$ZOMBIES" -gt 0 ]; then
               echo "- Remove unused translation keys from locale files" >> comment.md

--- a/scripts/check-translations.js
+++ b/scripts/check-translations.js
@@ -99,7 +99,9 @@ function checkCompleteness(locales) {
 
     const localeKeys = getAllKeys(locales[locale]).filter(key => !key.startsWith('testimonials.'));
     const missing = baseKeys.filter(key => !localeKeys.includes(key));
+    const missingKeys = new Set(missing);
     const untranslated = baseKeys.filter(key => {
+      if (missingKeys.has(key)) return false;
       if (SKIP_KEYS.has(key)) return false;
       const baseValue = getValue(locales[BASE_LOCALE], key);
       const localeValue = getValue(locales[locale], key);
@@ -107,8 +109,8 @@ function checkCompleteness(locales) {
     });
 
     const total = baseKeys.length;
-    const translated = total - missing.length;
-    const percentage = Math.round((translated / total) * 100);
+    const translated = total - missing.length - untranslated.length;
+    const percentage = total > 0 ? Math.round((translated / total) * 100) : 100;
 
     results[locale] = {
       total,
@@ -177,6 +179,11 @@ function generateReport(locales) {
       console.log(`         Missing: ${data.missingKeys.join(', ')}`);
     } else if (data.missingKeys.length > 10) {
       console.log(`         Missing: ${data.missingKeys.slice(0, 5).join(', ')} ... and ${data.missingKeys.length - 5} more`);
+    }
+    if (data.untranslatedKeys.length > 0 && data.untranslatedKeys.length <= 10) {
+      console.log(`         Untranslated: ${data.untranslatedKeys.join(', ')}`);
+    } else if (data.untranslatedKeys.length > 10) {
+      console.log(`         Untranslated: ${data.untranslatedKeys.slice(0, 5).join(', ')} ... and ${data.untranslatedKeys.length - 5} more`);
     }
     console.log();
   });


### PR DESCRIPTION
Summary:
- Count unchanged English strings as incomplete in the translation completeness percentage.
- Print untranslated key names in the translation report so translators can act on them.
- Include untranslated locales in the i18n workflow issue detection and PR comment output.

Validation:
- npm run i18n:check

Notes:
- This keeps the current workflow non-breaking while making the reported completion percentage accurate. Current average completion changes from 100% to 97% because existing locale files contain unchanged English strings.